### PR TITLE
feat: reduce admin discoverability in the public UI

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,4 +1,5 @@
-import { Routes, Route, Link, NavLink } from "react-router-dom";
+import { Routes, Route, Link, NavLink, Navigate } from "react-router-dom";
+import { apiConfig } from "@portfolio/shared";
 import { HomePage } from "./pages/HomePage.jsx";
 import { AdminPage } from "./pages/AdminPage.jsx";
 
@@ -10,13 +11,13 @@ export const App = () => (
       </Link>
       <nav className="nav">
         <NavLink to="/">Home</NavLink>
-        <NavLink to="/admin">Admin</NavLink>
       </nav>
     </header>
 
     <Routes>
       <Route path="/" element={<HomePage />} />
-      <Route path="/admin" element={<AdminPage />} />
+      <Route path={apiConfig.adminPath} element={<AdminPage />} />
+      <Route path="/admin" element={<Navigate to="/" replace />} />
     </Routes>
   </div>
 );

--- a/apps/web/src/pages/HomePage.jsx
+++ b/apps/web/src/pages/HomePage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { profile, skills } from "@portfolio/shared";
+import { Link } from "react-router-dom";
+import { apiConfig, profile, skills } from "@portfolio/shared";
 import { api } from "../lib/api.js";
 import { Badge, Banner, Button, Card, Input, Section, Textarea } from "../components/ui.jsx";
 
@@ -142,6 +143,13 @@ export const HomePage = () => {
           </form>
         </Card>
       </Section>
+
+      <footer className="site-footer">
+        <span>Operationally calm, intentionally low-profile.</span>
+        <Link className="admin-ghost-link" to={apiConfig.adminPath} aria-label="Private studio access">
+          .
+        </Link>
+      </footer>
     </main>
   );
 };

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -251,6 +251,31 @@ textarea {
   align-items: start;
 }
 
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem 0 1rem;
+  color: #7f92ad;
+  font-size: 0.9rem;
+}
+
+.admin-ghost-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  color: rgba(127, 146, 173, 0.2);
+  transition: color 120ms ease, transform 120ms ease;
+}
+
+.admin-ghost-link:hover,
+.admin-ghost-link:focus-visible {
+  color: #7fc4ff;
+  transform: scale(1.15);
+}
+
 @media (max-width: 900px) {
   .grid-2,
   .grid-3,

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -76,6 +76,7 @@ export const apiConfig = {
   webPort: 4173,
   apiPort: 4174,
   apiBaseUrl: "http://127.0.0.1:4174",
+  adminPath: "/studio-503",
   defaultJwtSecret: "dev-secret-change-me",
   defaultAdminPassword: "admin123"
 };


### PR DESCRIPTION
## Summary\n- remove the admin link from the primary navigation\n- move admin access to a lower-profile route\n- leave a subtle footer affordance for local/dev access\n- redirect the old /admin path back to home\n\n## Validation\n- verified http://localhost:4173 returns 200\n- verified http://localhost:4173/studio-503 returns 200