### PR TITLE
feat: hide the admin entrypoint from the public page

### DIFF
--- a/apps/web/src/pages/AdminPage.jsx
+++ b/apps/web/src/pages/AdminPage.jsx
@@ -145,7 +145,7 @@ export const AdminPage = () => {
   if (!authenticated) {
     return (
       <main className="page admin-page">
-        <Section title="Admin login" subtitle="Use the seeded development user to manage content locally.">
+        <Section title="Private workspace" subtitle="Restricted access.">
           {status.message ? (
             <Banner tone={status.type === "error" ? "error" : "info"}>{status.message}</Banner>
           ) : null}

--- a/apps/web/src/pages/HomePage.jsx
+++ b/apps/web/src/pages/HomePage.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
-import { apiConfig, profile, skills } from "@portfolio/shared";
+import { profile, skills } from "@portfolio/shared";
 import { api } from "../lib/api.js";
 import { Badge, Banner, Button, Card, Input, Section, Textarea } from "../components/ui.jsx";
 
@@ -143,13 +142,6 @@ export const HomePage = () => {
           </form>
         </Card>
       </Section>
-
-      <footer className="site-footer">
-        <span>Operationally calm, intentionally low-profile.</span>
-        <Link className="admin-ghost-link" to={apiConfig.adminPath} aria-label="Private studio access">
-          .
-        </Link>
-      </footer>
     </main>
   );
 };

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -251,31 +251,6 @@ textarea {
   align-items: start;
 }
 
-.site-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  padding: 2rem 0 1rem;
-  color: #7f92ad;
-  font-size: 0.9rem;
-}
-
-.admin-ghost-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1rem;
-  color: rgba(127, 146, 173, 0.2);
-  transition: color 120ms ease, transform 120ms ease;
-}
-
-.admin-ghost-link:hover,
-.admin-ghost-link:focus-visible {
-  color: #7fc4ff;
-  transform: scale(1.15);
-}
-
 @media (max-width: 900px) {
   .grid-2,
   .grid-3,


### PR DESCRIPTION
## Summary\n- remove the remaining footer affordance to the private workspace\n- keep access only through the direct private route\n- soften the login screen language so it reads as a private workspace instead of an obvious admin panel\n\n## Validation\n- verified http://localhost:4173 returns 200\n- verified http://localhost:4173/studio-503 returns 200