### PR TITLE
Modularize HTTP routes and validate admin sessions

### DIFF
--- a/apps/api/src/http/app.js
+++ b/apps/api/src/http/app.js
@@ -1,21 +1,12 @@
 import express from "express";
 import cors from "cors";
-import {
-  authenticateAdmin,
-  createPost,
-  createProject,
-  deletePost,
-  deleteProject,
-  listPosts,
-  listProjects,
-  submitContactForm,
-  updatePost,
-  updateProject
-} from "@portfolio/domain";
 import { createContainer } from "../infrastructure/container.js";
-import { asyncHandler, sendError } from "./errors.js";
-import { requireAdmin } from "./auth-middleware.js";
-import { rateLimit } from "../adapters/services/rate-limiter.js";
+import { sendError } from "./errors.js";
+import { ok } from "./respond.js";
+import { createAuthRouter } from "./routes/auth-routes.js";
+import { createProjectsRouter } from "./routes/projects-routes.js";
+import { createBlogRouter } from "./routes/blog-routes.js";
+import { createContactRouter } from "./routes/contact-routes.js";
 
 export const createApp = () => {
   const container = createContainer();
@@ -25,128 +16,13 @@ export const createApp = () => {
   app.use(express.json());
 
   app.get("/api/health", (_req, res) => {
-    res.json({ data: { ok: true } });
+    ok(res, { ok: true });
   });
 
-  app.post(
-    "/api/auth/login",
-    asyncHandler(async (req, res) => {
-      const limiter = rateLimit({
-        key: `login:${req.ip}`,
-        max: 20,
-        windowMs: 15 * 60 * 1000
-      });
-      if (!limiter.allowed) {
-        return sendError(
-          res,
-          Object.assign(new Error("Too many login attempts"), {
-            code: "RATE_LIMITED"
-          }),
-          429
-        );
-      }
-
-      const result = await authenticateAdmin(container, req.body);
-      res.json({ data: result });
-    })
-  );
-
-  app.get(
-    "/api/projects",
-    asyncHandler(async (_req, res) => {
-      const data = await listProjects(container);
-      res.json({ data });
-    })
-  );
-
-  app.post(
-    "/api/projects",
-    requireAdmin(container),
-    asyncHandler(async (req, res) => {
-      const data = await createProject(container, req.body);
-      res.status(201).json({ data });
-    })
-  );
-
-  app.put(
-    "/api/projects/:id",
-    requireAdmin(container),
-    asyncHandler(async (req, res) => {
-      const data = await updateProject(container, req.params.id, req.body);
-      res.json({ data });
-    })
-  );
-
-  app.delete(
-    "/api/projects/:id",
-    requireAdmin(container),
-    asyncHandler(async (req, res) => {
-      const data = await deleteProject(container, req.params.id);
-      res.json({ data });
-    })
-  );
-
-  app.get(
-    "/api/blog",
-    asyncHandler(async (req, res) => {
-      const published =
-        typeof req.query.published === "string"
-          ? req.query.published === "true"
-          : undefined;
-      const data = await listPosts(container, { published });
-      res.json({ data });
-    })
-  );
-
-  app.post(
-    "/api/blog",
-    requireAdmin(container),
-    asyncHandler(async (req, res) => {
-      const data = await createPost(container, req.body);
-      res.status(201).json({ data });
-    })
-  );
-
-  app.put(
-    "/api/blog/:id",
-    requireAdmin(container),
-    asyncHandler(async (req, res) => {
-      const data = await updatePost(container, req.params.id, req.body);
-      res.json({ data });
-    })
-  );
-
-  app.delete(
-    "/api/blog/:id",
-    requireAdmin(container),
-    asyncHandler(async (req, res) => {
-      const data = await deletePost(container, req.params.id);
-      res.json({ data });
-    })
-  );
-
-  app.post(
-    "/api/contact",
-    asyncHandler(async (req, res) => {
-      const limiter = rateLimit({
-        key: `contact:${req.ip}`,
-        max: 10,
-        windowMs: 60 * 60 * 1000
-      });
-      if (!limiter.allowed) {
-        return sendError(
-          res,
-          Object.assign(new Error("Too many contact submissions"), {
-            code: "RATE_LIMITED"
-          }),
-          429
-        );
-      }
-
-      const data = await submitContactForm(container, req.body);
-      res.status(201).json({ data });
-    })
-  );
+  app.use("/api/auth", createAuthRouter(container));
+  app.use("/api/projects", createProjectsRouter(container));
+  app.use("/api/blog", createBlogRouter(container));
+  app.use("/api/contact", createContactRouter(container));
 
   app.use((error, _req, res, _next) => {
     if (error.code === "INVALID_CREDENTIALS") {

--- a/apps/api/src/http/app.test.js
+++ b/apps/api/src/http/app.test.js
@@ -22,4 +22,10 @@ describe("API", () => {
     expect(response.statusCode).toBe(400);
     expect(response.body.error.code).toBe("VALIDATION_ERROR");
   });
+
+  it("returns 401 for auth session without token", async () => {
+    const response = await request(app).get("/api/auth/session");
+    expect(response.statusCode).toBe(401);
+    expect(response.body.error.code).toBe("AUTH_REQUIRED");
+  });
 });

--- a/apps/api/src/http/rate-limit.js
+++ b/apps/api/src/http/rate-limit.js
@@ -1,0 +1,25 @@
+import { rateLimit } from "../adapters/services/rate-limiter.js";
+import { sendError } from "./errors.js";
+
+export const withRateLimit =
+  ({ keyPrefix, max, windowMs }) =>
+  (handler) =>
+  async (req, res) => {
+    const limiter = rateLimit({
+      key: `${keyPrefix}:${req.ip}`,
+      max,
+      windowMs
+    });
+
+    if (!limiter.allowed) {
+      return sendError(
+        res,
+        Object.assign(new Error("Rate limit exceeded"), {
+          code: "RATE_LIMITED"
+        }),
+        429
+      );
+    }
+
+    return handler(req, res);
+  };

--- a/apps/api/src/http/respond.js
+++ b/apps/api/src/http/respond.js
@@ -1,0 +1,3 @@
+export const ok = (res, data, status = 200) => {
+  res.status(status).json({ data });
+};

--- a/apps/api/src/http/routes/auth-routes.js
+++ b/apps/api/src/http/routes/auth-routes.js
@@ -1,0 +1,40 @@
+import express from "express";
+import { authenticateAdmin } from "@portfolio/domain";
+import { asyncHandler } from "../errors.js";
+import { ok } from "../respond.js";
+import { requireAdmin } from "../auth-middleware.js";
+import { withRateLimit } from "../rate-limit.js";
+
+export const createAuthRouter = (container) => {
+  const router = express.Router();
+
+  router.post(
+    "/login",
+    asyncHandler(
+      withRateLimit({
+        keyPrefix: "login",
+        max: 20,
+        windowMs: 15 * 60 * 1000
+      })(async (req, res) => {
+        const result = await authenticateAdmin(container, req.body);
+        ok(res, result);
+      })
+    )
+  );
+
+  router.get(
+    "/session",
+    requireAdmin(container),
+    asyncHandler(async (req, res) => {
+      ok(res, {
+        user: {
+          id: req.auth.sub,
+          username: req.auth.username,
+          role: req.auth.role
+        }
+      });
+    })
+  );
+
+  return router;
+};

--- a/apps/api/src/http/routes/blog-routes.js
+++ b/apps/api/src/http/routes/blog-routes.js
@@ -1,0 +1,51 @@
+import express from "express";
+import {
+  createPost,
+  deletePost,
+  listPosts,
+  updatePost
+} from "@portfolio/domain";
+import { requireAdmin } from "../auth-middleware.js";
+import { asyncHandler } from "../errors.js";
+import { ok } from "../respond.js";
+
+export const createBlogRouter = (container) => {
+  const router = express.Router();
+
+  router.get(
+    "/",
+    asyncHandler(async (req, res) => {
+      const published =
+        typeof req.query.published === "string"
+          ? req.query.published === "true"
+          : undefined;
+      ok(res, await listPosts(container, { published }));
+    })
+  );
+
+  router.post(
+    "/",
+    requireAdmin(container),
+    asyncHandler(async (req, res) => {
+      ok(res, await createPost(container, req.body), 201);
+    })
+  );
+
+  router.put(
+    "/:id",
+    requireAdmin(container),
+    asyncHandler(async (req, res) => {
+      ok(res, await updatePost(container, req.params.id, req.body));
+    })
+  );
+
+  router.delete(
+    "/:id",
+    requireAdmin(container),
+    asyncHandler(async (req, res) => {
+      ok(res, await deletePost(container, req.params.id));
+    })
+  );
+
+  return router;
+};

--- a/apps/api/src/http/routes/contact-routes.js
+++ b/apps/api/src/http/routes/contact-routes.js
@@ -1,0 +1,24 @@
+import express from "express";
+import { submitContactForm } from "@portfolio/domain";
+import { asyncHandler } from "../errors.js";
+import { ok } from "../respond.js";
+import { withRateLimit } from "../rate-limit.js";
+
+export const createContactRouter = (container) => {
+  const router = express.Router();
+
+  router.post(
+    "/",
+    asyncHandler(
+      withRateLimit({
+        keyPrefix: "contact",
+        max: 10,
+        windowMs: 60 * 60 * 1000
+      })(async (req, res) => {
+        ok(res, await submitContactForm(container, req.body), 201);
+      })
+    )
+  );
+
+  return router;
+};

--- a/apps/api/src/http/routes/projects-routes.js
+++ b/apps/api/src/http/routes/projects-routes.js
@@ -1,0 +1,47 @@
+import express from "express";
+import {
+  createProject,
+  deleteProject,
+  listProjects,
+  updateProject
+} from "@portfolio/domain";
+import { requireAdmin } from "../auth-middleware.js";
+import { asyncHandler } from "../errors.js";
+import { ok } from "../respond.js";
+
+export const createProjectsRouter = (container) => {
+  const router = express.Router();
+
+  router.get(
+    "/",
+    asyncHandler(async (_req, res) => {
+      ok(res, await listProjects(container));
+    })
+  );
+
+  router.post(
+    "/",
+    requireAdmin(container),
+    asyncHandler(async (req, res) => {
+      ok(res, await createProject(container, req.body), 201);
+    })
+  );
+
+  router.put(
+    "/:id",
+    requireAdmin(container),
+    asyncHandler(async (req, res) => {
+      ok(res, await updateProject(container, req.params.id, req.body));
+    })
+  );
+
+  router.delete(
+    "/:id",
+    requireAdmin(container),
+    asyncHandler(async (req, res) => {
+      ok(res, await deleteProject(container, req.params.id));
+    })
+  );
+
+  return router;
+};

--- a/apps/web/src/lib/api.js
+++ b/apps/web/src/lib/api.js
@@ -16,6 +16,15 @@ export const api = {
       })
     );
   },
+  async getSession(token) {
+    return readJson(
+      await fetch("/api/auth/session", {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      })
+    );
+  },
   async listProjects() {
     return readJson(await fetch("/api/projects"));
   },

--- a/apps/web/src/pages/AdminPage.jsx
+++ b/apps/web/src/pages/AdminPage.jsx
@@ -30,7 +30,8 @@ const mapDelimited = (value) =>
 
 export const AdminPage = () => {
   const [token, setToken] = useState(localStorage.getItem(tokenKey) ?? "");
-  const [login, setLogin] = useState({ username: "admin", password: "admin123" });
+  const [login, setLogin] = useState({ username: "", password: "" });
+  const [sessionChecked, setSessionChecked] = useState(false);
   const [projects, setProjects] = useState([]);
   const [posts, setPosts] = useState([]);
   const [projectForm, setProjectForm] = useState(blankProject);
@@ -52,10 +53,19 @@ export const AdminPage = () => {
 
   useEffect(() => {
     if (!authenticated) {
+      setSessionChecked(true);
       return;
     }
-    load().catch((error) => setStatus({ type: "error", message: error.message }));
-  }, [authenticated]);
+
+    api
+      .getSession(token)
+      .then(() => load())
+      .catch(() => {
+        localStorage.removeItem(tokenKey);
+        setToken("");
+      })
+      .finally(() => setSessionChecked(true));
+  }, [authenticated, token]);
 
   const editingProject = useMemo(
     () => projects.find((item) => item.id === editingProjectId) ?? null,
@@ -141,6 +151,18 @@ export const AdminPage = () => {
     await api.deletePost(id, token);
     setPosts((current) => current.filter((item) => item.id !== id));
   };
+
+  if (!sessionChecked) {
+    return (
+      <main className="page admin-page">
+        <Section title="Private workspace" subtitle="Checking access.">
+          <Card className="private-shell">
+            <p>Verifying session...</p>
+          </Card>
+        </Section>
+      </main>
+    );
+  }
 
   if (!authenticated) {
     return (


### PR DESCRIPTION
## Summary
- split the API HTTP surface into dedicated auth, projects, blog and contact routers
- add reusable response and rate limit helpers plus a session endpoint for private workspace validation
- validate stored admin sessions from the web client before loading workspace data

## Testing
- npm run lint
- npm run test -w @portfolio/api
- npm run test -w @portfolio/web