### PR TITLE
Adopt react-query for frontend server state

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@portfolio/shared": "*",
+    "@tanstack/react-query": "^5.96.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.0"

--- a/apps/web/src/App.test.jsx
+++ b/apps/web/src/App.test.jsx
@@ -1,7 +1,9 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { App } from "./App.jsx";
+import { routerFuture } from "./lib/router-future.js";
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -65,13 +67,27 @@ beforeEach(() => {
   );
 });
 
-describe("App routes", () => {
-  it("renders the public home content", async () => {
-    render(
-      <MemoryRouter initialEntries={["/"]}>
+const renderWithProviders = (initialEntries) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter future={routerFuture} initialEntries={initialEntries}>
         <App />
       </MemoryRouter>
-    );
+    </QueryClientProvider>
+  );
+};
+
+describe("App routes", () => {
+  it("renders the public home content", async () => {
+    renderWithProviders(["/"]);
 
     expect(screen.getByText("David Fernandez-Cuenca Marcos")).toBeInTheDocument();
 
@@ -82,11 +98,7 @@ describe("App routes", () => {
   });
 
   it("renders the private workspace shell on the private route", () => {
-    render(
-      <MemoryRouter initialEntries={["/studio-503"]}>
-        <App />
-      </MemoryRouter>
-    );
+    renderWithProviders(["/studio-503"]);
 
     expect(screen.getByText("Private workspace")).toBeInTheDocument();
     expect(screen.getByLabelText("Identifier")).toBeInTheDocument();

--- a/apps/web/src/lib/query-client.js
+++ b/apps/web/src/lib/query-client.js
@@ -1,0 +1,10 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1
+    }
+  }
+});

--- a/apps/web/src/lib/router-future.js
+++ b/apps/web/src/lib/router-future.js
@@ -1,0 +1,4 @@
+export const routerFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true
+};

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -1,12 +1,17 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App.jsx";
+import { queryClient } from "./lib/query-client.js";
+import { routerFuture } from "./lib/router-future.js";
 import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter future={routerFuture}>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/apps/web/src/pages/AdminPage.jsx
+++ b/apps/web/src/pages/AdminPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api.js";
 import { Badge, Banner, Button, Card, Input, Section, Textarea } from "../components/ui.jsx";
 
@@ -29,11 +30,9 @@ const mapDelimited = (value) =>
     .filter(Boolean);
 
 export const AdminPage = () => {
+  const queryClient = useQueryClient();
   const [token, setToken] = useState(localStorage.getItem(tokenKey) ?? "");
   const [login, setLogin] = useState({ username: "", password: "" });
-  const [sessionChecked, setSessionChecked] = useState(false);
-  const [projects, setProjects] = useState([]);
-  const [posts, setPosts] = useState([]);
   const [projectForm, setProjectForm] = useState(blankProject);
   const [postForm, setPostForm] = useState(blankPost);
   const [editingProjectId, setEditingProjectId] = useState("");
@@ -41,39 +40,40 @@ export const AdminPage = () => {
   const [status, setStatus] = useState({ type: "idle", message: "" });
 
   const authenticated = Boolean(token);
+  const sessionQuery = useQuery({
+    queryKey: ["admin-session", token],
+    queryFn: () => api.getSession(token),
+    enabled: authenticated,
+    retry: false
+  });
+  const workspaceQuery = useQuery({
+    queryKey: ["admin-workspace"],
+    queryFn: async () => {
+      const [projects, posts] = await Promise.all([
+        api.listProjects(),
+        api.listPosts()
+      ]);
 
-  const load = async () => {
-    const [projectList, postList] = await Promise.all([
-      api.listProjects(),
-      api.listPosts()
-    ]);
-    setProjects(projectList);
-    setPosts(postList);
-  };
-
+      return { projects, posts };
+    },
+    enabled: authenticated && sessionQuery.isSuccess
+  });
   useEffect(() => {
-    if (!authenticated) {
-      setSessionChecked(true);
-      return;
+    if (authenticated && sessionQuery.isError) {
+      localStorage.removeItem(tokenKey);
+      queryClient.removeQueries({ queryKey: ["admin-session"] });
+      queryClient.removeQueries({ queryKey: ["admin-workspace"] });
+      setToken("");
     }
-
-    api
-      .getSession(token)
-      .then(() => load())
-      .catch(() => {
-        localStorage.removeItem(tokenKey);
-        setToken("");
-      })
-      .finally(() => setSessionChecked(true));
-  }, [authenticated, token]);
+  }, [authenticated, queryClient, sessionQuery.isError]);
 
   const editingProject = useMemo(
-    () => projects.find((item) => item.id === editingProjectId) ?? null,
-    [projects, editingProjectId]
+    () => (workspaceQuery.data?.projects ?? []).find((item) => item.id === editingProjectId) ?? null,
+    [workspaceQuery.data?.projects, editingProjectId]
   );
   const editingPost = useMemo(
-    () => posts.find((item) => item.id === editingPostId) ?? null,
-    [posts, editingPostId]
+    () => (workspaceQuery.data?.posts ?? []).find((item) => item.id === editingPostId) ?? null,
+    [workspaceQuery.data?.posts, editingPostId]
   );
 
   useEffect(() => {
@@ -106,7 +106,7 @@ export const AdminPage = () => {
 
   const handleProjectSubmit = async (event) => {
     event.preventDefault();
-    const saved = await api.saveProject(
+    await api.saveProject(
       {
         ...projectForm,
         id: editingProjectId || undefined,
@@ -118,15 +118,12 @@ export const AdminPage = () => {
     );
     setEditingProjectId("");
     setProjectForm(blankProject);
-    setProjects((current) => {
-      const filtered = current.filter((item) => item.id !== saved.id);
-      return [saved, ...filtered];
-    });
+    await queryClient.invalidateQueries({ queryKey: ["admin-workspace"] });
   };
 
   const handlePostSubmit = async (event) => {
     event.preventDefault();
-    const saved = await api.savePost(
+    await api.savePost(
       {
         ...postForm,
         id: editingPostId || undefined,
@@ -136,23 +133,20 @@ export const AdminPage = () => {
     );
     setEditingPostId("");
     setPostForm(blankPost);
-    setPosts((current) => {
-      const filtered = current.filter((item) => item.id !== saved.id);
-      return [saved, ...filtered];
-    });
+    await queryClient.invalidateQueries({ queryKey: ["admin-workspace"] });
   };
 
   const handleDeleteProject = async (id) => {
     await api.deleteProject(id, token);
-    setProjects((current) => current.filter((item) => item.id !== id));
+    await queryClient.invalidateQueries({ queryKey: ["admin-workspace"] });
   };
 
   const handleDeletePost = async (id) => {
     await api.deletePost(id, token);
-    setPosts((current) => current.filter((item) => item.id !== id));
+    await queryClient.invalidateQueries({ queryKey: ["admin-workspace"] });
   };
 
-  if (!sessionChecked) {
+  if (authenticated && sessionQuery.isPending) {
     return (
       <main className="page admin-page">
         <Section title="Private workspace" subtitle="Checking access.">
@@ -203,6 +197,9 @@ export const AdminPage = () => {
       {status.message ? (
         <Banner tone={status.type === "error" ? "error" : "info"}>{status.message}</Banner>
       ) : null}
+      {workspaceQuery.isError ? (
+        <Banner tone="error">{workspaceQuery.error.message}</Banner>
+      ) : null}
 
       <Section
         title="Projects"
@@ -213,6 +210,8 @@ export const AdminPage = () => {
             onClick={() => {
               localStorage.removeItem(tokenKey);
               setToken("");
+              queryClient.removeQueries({ queryKey: ["admin-session"] });
+              queryClient.removeQueries({ queryKey: ["admin-workspace"] });
             }}
           >
             Log out
@@ -282,7 +281,8 @@ export const AdminPage = () => {
           </Card>
           <Card>
             <div className="stack">
-              {projects.map((project) => (
+              {workspaceQuery.isLoading ? <p>Loading projects...</p> : null}
+              {(workspaceQuery.data?.projects ?? []).map((project) => (
                 <div className="list-item" key={project.id}>
                   <div>
                     <h3>{project.title}</h3>
@@ -360,7 +360,8 @@ export const AdminPage = () => {
           </Card>
           <Card>
             <div className="stack">
-              {posts.map((post) => (
+              {workspaceQuery.isLoading ? <p>Loading posts...</p> : null}
+              {(workspaceQuery.data?.posts ?? []).map((post) => (
                 <div className="list-item" key={post.id}>
                   <div>
                     <div className="card-header">

--- a/apps/web/src/pages/HomePage.jsx
+++ b/apps/web/src/pages/HomePage.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { profile, skills } from "@portfolio/shared";
 import { api } from "../lib/api.js";
 import { Badge, Banner, Button, Card, Input, Section, Textarea } from "../components/ui.jsx";
@@ -11,29 +12,24 @@ const emptyContact = {
 };
 
 export const HomePage = () => {
-  const [projects, setProjects] = useState([]);
-  const [posts, setPosts] = useState([]);
-  const [status, setStatus] = useState({ type: "idle", message: "" });
+  const [contactStatus, setContactStatus] = useState({ type: "idle", message: "" });
   const [contact, setContact] = useState(emptyContact);
 
-  useEffect(() => {
-    const load = async () => {
-      const [projectList, postList] = await Promise.all([
+  const contentQuery = useQuery({
+    queryKey: ["home-content"],
+    queryFn: async () => {
+      const [projects, posts] = await Promise.all([
         api.listProjects(),
         api.listPosts(true)
       ]);
-      setProjects(projectList);
-      setPosts(postList);
-    };
 
-    load().catch((error) => {
-      setStatus({ type: "error", message: error.message });
-    });
-  }, []);
+      return { projects, posts };
+    }
+  });
 
   const featuredProjects = useMemo(
-    () => projects.filter((item) => item.featured),
-    [projects]
+    () => (contentQuery.data?.projects ?? []).filter((item) => item.featured),
+    [contentQuery.data?.projects]
   );
 
   const handleChange = (event) => {
@@ -43,14 +39,14 @@ export const HomePage = () => {
 
   const handleSubmit = async (event) => {
     event.preventDefault();
-    setStatus({ type: "loading", message: "Sending message..." });
+    setContactStatus({ type: "loading", message: "Sending message..." });
 
     try {
       const result = await api.submitContact(contact);
-      setStatus({ type: "success", message: result.message });
+      setContactStatus({ type: "success", message: result.message });
       setContact(emptyContact);
     } catch (error) {
-      setStatus({ type: "error", message: error.message });
+      setContactStatus({ type: "error", message: error.message });
     }
   };
 
@@ -73,7 +69,14 @@ export const HomePage = () => {
         </div>
       </section>
 
-      {status.message ? <Banner tone={status.type === "error" ? "error" : "info"}>{status.message}</Banner> : null}
+      {contentQuery.isError ? (
+        <Banner tone="error">{contentQuery.error.message}</Banner>
+      ) : null}
+      {contactStatus.message ? (
+        <Banner tone={contactStatus.type === "error" ? "error" : "info"}>
+          {contactStatus.message}
+        </Banner>
+      ) : null}
 
       <Section title="About" subtitle="A portfolio should expose technical depth and product judgment, not just static cards.">
         <Card>
@@ -97,38 +100,50 @@ export const HomePage = () => {
       </Section>
 
       <Section title="Featured projects" subtitle="Live content served by the API">
-        <div className="grid grid-2">
-          {featuredProjects.map((project) => (
-            <Card key={project.id}>
-              <div className="card-header">
-                <h3>{project.title}</h3>
-                <Badge>{project.status}</Badge>
-              </div>
-              <p>{project.description}</p>
-              <div className="badge-row">
-                {project.technologies.map((tech) => (
-                  <Badge key={tech}>{tech}</Badge>
-                ))}
-              </div>
-            </Card>
-          ))}
-        </div>
+        {contentQuery.isLoading ? (
+          <Card>
+            <p>Loading featured projects...</p>
+          </Card>
+        ) : (
+          <div className="grid grid-2">
+            {featuredProjects.map((project) => (
+              <Card key={project.id}>
+                <div className="card-header">
+                  <h3>{project.title}</h3>
+                  <Badge>{project.status}</Badge>
+                </div>
+                <p>{project.description}</p>
+                <div className="badge-row">
+                  {project.technologies.map((tech) => (
+                    <Badge key={tech}>{tech}</Badge>
+                  ))}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
       </Section>
 
       <Section title="Blog" subtitle="Published posts only">
-        <div className="grid grid-2">
-          {posts.map((post) => (
-            <Card key={post.id}>
-              <h3>{post.title}</h3>
-              <p>{post.excerpt}</p>
-              <div className="badge-row">
-                {post.tags.map((tag) => (
-                  <Badge key={tag}>{tag}</Badge>
-                ))}
-              </div>
-            </Card>
-          ))}
-        </div>
+        {contentQuery.isLoading ? (
+          <Card>
+            <p>Loading published posts...</p>
+          </Card>
+        ) : (
+          <div className="grid grid-2">
+            {(contentQuery.data?.posts ?? []).map((post) => (
+              <Card key={post.id}>
+                <h3>{post.title}</h3>
+                <p>{post.excerpt}</p>
+                <div className="badge-row">
+                  {post.tags.map((tag) => (
+                    <Badge key={tag}>{tag}</Badge>
+                  ))}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
       </Section>
 
       <Section title="Contact" subtitle="Server-backed contact workflow with validation and rate limiting">

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@portfolio/shared": "*",
+        "@tanstack/react-query": "^5.96.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.0"
@@ -1601,6 +1602,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.0.tgz",
+      "integrity": "sha512-sfO3uQeol1BU7cRP6NYY7nAiX3GiNY20lI/dtSbKLwcIkYw/X+w/tEsQAkc544AfIhBX/IvH/QYtPHrPhyAKGw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.0.tgz",
+      "integrity": "sha512-6qbjdm1K5kizVKv9TNqhIN3doq2anRhdF2XaFMFSn4m8L22S69RV+FilvlyVT4RoJyMxtPU5rs4RpdFa/PEC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.96.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",


### PR DESCRIPTION
## Summary
- add react-query as the standard server-state layer for the web workspace
- move public and private workspace content loading onto query-based flows
- opt into router future flags in app runtime and tests to remove warning noise

## Testing
- npm run lint
- npm run test -w @portfolio/web
- npm run test -w @portfolio/api