### PR TITLE
Share form schemas across web and domain

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,11 +9,14 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@portfolio/shared": "*",
     "@tanstack/react-query": "^5.96.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.0"
+    "react-hook-form": "^7.72.0",
+    "react-router-dom": "^6.30.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/apps/web/src/components/ui.jsx
+++ b/apps/web/src/components/ui.jsx
@@ -1,3 +1,5 @@
+import { forwardRef } from "react";
+
 export const Section = ({ title, subtitle, children, actions }) => (
   <section className="section">
     <div className="section-heading">
@@ -19,22 +21,25 @@ export const Button = ({ variant = "primary", className = "", ...props }) => (
   <button className={`button ${variant} ${className}`.trim()} {...props} />
 );
 
-export const Input = ({ label, ...props }) => (
+export const Input = forwardRef(({ label, ...props }, ref) => (
   <label className="field">
     <span>{label}</span>
-    <input {...props} />
+    <input ref={ref} {...props} />
   </label>
-);
+));
 
-export const Textarea = ({ label, ...props }) => (
+export const Textarea = forwardRef(({ label, ...props }, ref) => (
   <label className="field">
     <span>{label}</span>
-    <textarea {...props} />
+    <textarea ref={ref} {...props} />
   </label>
-);
+));
 
 export const Badge = ({ children }) => <span className="badge">{children}</span>;
 
 export const Banner = ({ tone = "info", children }) => (
   <div className={`banner ${tone}`}>{children}</div>
 );
+
+export const FieldError = ({ message }) =>
+  message ? <span className="field-error">{message}</span> : null;

--- a/apps/web/src/pages/AdminPage.jsx
+++ b/apps/web/src/pages/AdminPage.jsx
@@ -1,7 +1,19 @@
 import { useEffect, useMemo, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { loginInputSchema } from "@portfolio/shared";
 import { api } from "../lib/api.js";
-import { Badge, Banner, Button, Card, Input, Section, Textarea } from "../components/ui.jsx";
+import {
+  Badge,
+  Banner,
+  Button,
+  Card,
+  FieldError,
+  Input,
+  Section,
+  Textarea
+} from "../components/ui.jsx";
 
 const tokenKey = "portfolio-admin-token";
 
@@ -32,12 +44,18 @@ const mapDelimited = (value) =>
 export const AdminPage = () => {
   const queryClient = useQueryClient();
   const [token, setToken] = useState(localStorage.getItem(tokenKey) ?? "");
-  const [login, setLogin] = useState({ username: "", password: "" });
   const [projectForm, setProjectForm] = useState(blankProject);
   const [postForm, setPostForm] = useState(blankPost);
   const [editingProjectId, setEditingProjectId] = useState("");
   const [editingPostId, setEditingPostId] = useState("");
   const [status, setStatus] = useState({ type: "idle", message: "" });
+  const loginForm = useForm({
+    resolver: zodResolver(loginInputSchema),
+    defaultValues: {
+      username: "",
+      password: ""
+    }
+  });
 
   const authenticated = Boolean(token);
   const sessionQuery = useQuery({
@@ -92,17 +110,17 @@ export const AdminPage = () => {
     }
   }, [editingPost]);
 
-  const handleLogin = async (event) => {
-    event.preventDefault();
+  const handleLogin = loginForm.handleSubmit(async (values) => {
     try {
-      const result = await api.login(login);
+      const result = await api.login(values);
       localStorage.setItem(tokenKey, result.token);
       setToken(result.token);
+      loginForm.reset();
       setStatus({ type: "success", message: `Signed in as ${result.user.username}` });
     } catch (error) {
       setStatus({ type: "error", message: error.message });
     }
-  };
+  });
 
   const handleProjectSubmit = async (event) => {
     event.preventDefault();
@@ -167,24 +185,21 @@ export const AdminPage = () => {
           ) : null}
           <Card className="private-shell">
             <form className="form-grid" onSubmit={handleLogin}>
-              <Input
-                label="Identifier"
-                name="username"
-                value={login.username}
-                onChange={(event) =>
-                  setLogin((current) => ({ ...current, username: event.target.value }))
-                }
-              />
-              <Input
-                label="Passphrase"
-                type="password"
-                name="password"
-                value={login.password}
-                onChange={(event) =>
-                  setLogin((current) => ({ ...current, password: event.target.value }))
-                }
-              />
-              <Button type="submit">Continue</Button>
+              <div>
+                <Input label="Identifier" {...loginForm.register("username")} />
+                <FieldError message={loginForm.formState.errors.username?.message} />
+              </div>
+              <div>
+                <Input
+                  label="Passphrase"
+                  type="password"
+                  {...loginForm.register("password")}
+                />
+                <FieldError message={loginForm.formState.errors.password?.message} />
+              </div>
+              <Button type="submit" disabled={loginForm.formState.isSubmitting}>
+                {loginForm.formState.isSubmitting ? "Checking..." : "Continue"}
+              </Button>
             </form>
           </Card>
         </Section>

--- a/apps/web/src/pages/HomePage.jsx
+++ b/apps/web/src/pages/HomePage.jsx
@@ -1,19 +1,31 @@
 import { useMemo, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery } from "@tanstack/react-query";
-import { profile, skills } from "@portfolio/shared";
+import { useForm } from "react-hook-form";
+import { contactInputSchema, profile, skills } from "@portfolio/shared";
 import { api } from "../lib/api.js";
-import { Badge, Banner, Button, Card, Input, Section, Textarea } from "../components/ui.jsx";
-
-const emptyContact = {
-  name: "",
-  email: "",
-  subject: "",
-  message: ""
-};
+import {
+  Badge,
+  Banner,
+  Button,
+  Card,
+  FieldError,
+  Input,
+  Section,
+  Textarea
+} from "../components/ui.jsx";
 
 export const HomePage = () => {
   const [contactStatus, setContactStatus] = useState({ type: "idle", message: "" });
-  const [contact, setContact] = useState(emptyContact);
+  const contactForm = useForm({
+    resolver: zodResolver(contactInputSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      subject: "",
+      message: ""
+    }
+  });
 
   const contentQuery = useQuery({
     queryKey: ["home-content"],
@@ -32,23 +44,17 @@ export const HomePage = () => {
     [contentQuery.data?.projects]
   );
 
-  const handleChange = (event) => {
-    const { name, value } = event.target;
-    setContact((current) => ({ ...current, [name]: value }));
-  };
-
-  const handleSubmit = async (event) => {
-    event.preventDefault();
+  const handleSubmit = contactForm.handleSubmit(async (values) => {
     setContactStatus({ type: "loading", message: "Sending message..." });
 
     try {
-      const result = await api.submitContact(contact);
+      const result = await api.submitContact(values);
       setContactStatus({ type: "success", message: result.message });
-      setContact(emptyContact);
+      contactForm.reset();
     } catch (error) {
       setContactStatus({ type: "error", message: error.message });
     }
-  };
+  });
 
   return (
     <main className="page">
@@ -149,11 +155,25 @@ export const HomePage = () => {
       <Section title="Contact" subtitle="Server-backed contact workflow with validation and rate limiting">
         <Card>
           <form className="form-grid" onSubmit={handleSubmit}>
-            <Input label="Name" name="name" value={contact.name} onChange={handleChange} required />
-            <Input label="Email" name="email" type="email" value={contact.email} onChange={handleChange} required />
-            <Input label="Subject" name="subject" value={contact.subject} onChange={handleChange} required />
-            <Textarea label="Message" name="message" rows="6" value={contact.message} onChange={handleChange} required />
-            <Button type="submit">Send message</Button>
+            <div>
+              <Input label="Name" {...contactForm.register("name")} />
+              <FieldError message={contactForm.formState.errors.name?.message} />
+            </div>
+            <div>
+              <Input label="Email" type="email" {...contactForm.register("email")} />
+              <FieldError message={contactForm.formState.errors.email?.message} />
+            </div>
+            <div>
+              <Input label="Subject" {...contactForm.register("subject")} />
+              <FieldError message={contactForm.formState.errors.subject?.message} />
+            </div>
+            <div>
+              <Textarea label="Message" rows="6" {...contactForm.register("message")} />
+              <FieldError message={contactForm.formState.errors.message?.message} />
+            </div>
+            <Button type="submit" disabled={contactForm.formState.isSubmitting}>
+              {contactForm.formState.isSubmitting ? "Sending..." : "Send message"}
+            </Button>
           </form>
         </Card>
       </Section>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -228,6 +228,11 @@ textarea {
   resize: vertical;
 }
 
+.field-error {
+  color: #ff9aa2;
+  font-size: 0.85rem;
+}
+
 .form-grid {
   display: grid;
   gap: 1rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,11 +47,14 @@
       "name": "@portfolio/web",
       "version": "1.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@portfolio/shared": "*",
         "@tanstack/react-query": "^5.96.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.30.0"
+        "react-hook-form": "^7.72.0",
+        "react-router-dom": "^6.30.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -60,6 +63,15 @@
         "jsdom": "^26.0.0",
         "vite": "^6.2.1",
         "vitest": "^2.1.9"
+      }
+    },
+    "apps/web/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1096,6 +1108,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1602,6 +1626,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.96.0",
@@ -5650,6 +5680,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.72.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.0.tgz",
+      "integrity": "sha512-V4v6jubaf6JAurEaVnT9aUPKFbNtDgohj5CIgVGyPHvT9wRx5OZHVjz31GsxnPNI278XMu+ruFz+wGOscHaLKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/packages/domain/src/index.js
+++ b/packages/domain/src/index.js
@@ -1,44 +1,10 @@
-import { z } from "zod";
-
 const isoNow = () => new Date().toISOString();
-const nonEmptyString = z.string().trim().min(1);
-const optionalUrl = z
-  .string()
-  .trim()
-  .url()
-  .or(z.literal(""))
-  .optional()
-  .default("");
-
-export const projectInputSchema = z.object({
-  title: nonEmptyString,
-  description: z.string().trim().min(1),
-  technologies: z.array(nonEmptyString).default([]),
-  githubUrl: optionalUrl,
-  liveUrl: optionalUrl,
-  featured: z.boolean().default(false),
-  status: z.enum(["active", "draft", "archived"]).default("active")
-});
-
-export const blogPostInputSchema = z.object({
-  title: nonEmptyString,
-  excerpt: z.string().trim().min(1),
-  content: z.string().trim().min(1),
-  tags: z.array(nonEmptyString).default([]),
-  published: z.boolean().default(false)
-});
-
-export const contactInputSchema = z.object({
-  name: nonEmptyString,
-  email: z.string().trim().email(),
-  subject: nonEmptyString,
-  message: z.string().trim().min(10)
-});
-
-export const loginInputSchema = z.object({
-  username: nonEmptyString,
-  password: nonEmptyString
-});
+import {
+  blogPostInputSchema,
+  contactInputSchema,
+  loginInputSchema,
+  projectInputSchema
+} from "@portfolio/shared";
 
 const mapProject = (project, input) => ({
   ...project,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,5 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
   }
 }

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -1,3 +1,44 @@
+import { z } from "zod";
+
+const nonEmptyString = z.string().trim().min(1);
+const optionalUrl = z
+  .string()
+  .trim()
+  .url()
+  .or(z.literal(""))
+  .optional()
+  .default("");
+
+export const projectInputSchema = z.object({
+  title: nonEmptyString,
+  description: z.string().trim().min(1),
+  technologies: z.array(nonEmptyString).default([]),
+  githubUrl: optionalUrl,
+  liveUrl: optionalUrl,
+  featured: z.boolean().default(false),
+  status: z.enum(["active", "draft", "archived"]).default("active")
+});
+
+export const blogPostInputSchema = z.object({
+  title: nonEmptyString,
+  excerpt: z.string().trim().min(1),
+  content: z.string().trim().min(1),
+  tags: z.array(nonEmptyString).default([]),
+  published: z.boolean().default(false)
+});
+
+export const contactInputSchema = z.object({
+  name: nonEmptyString,
+  email: z.string().trim().email(),
+  subject: nonEmptyString,
+  message: z.string().trim().min(10)
+});
+
+export const loginInputSchema = z.object({
+  username: nonEmptyString,
+  password: nonEmptyString
+});
+
 export const profile = {
   name: "David Fernandez-Cuenca Marcos",
   role: "Software Engineer",


### PR DESCRIPTION
## Summary
- move contact and login zod schemas into the shared package so web and domain validate against the same contracts
- adopt react-hook-form with zod resolvers for the public contact form and the private workspace login
- forward input refs and render inline field errors in the shared UI components

## Testing
- npm run lint
- npm run test -w @portfolio/web
- npm run test -w @portfolio/api