### PR TITLE
Document architecture and working agreements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## Purpose
+
+This repository is maintained through small, mergeable slices. Future agents should optimize for incremental progress, clear boundaries and a stable local dev workflow.
+
+## Non-negotiables
+
+- branch from `dev`
+- open a PR for each coherent change set
+- merge back into `dev`
+- keep `npm run dev` working locally
+- do not introduce `npm build` as a required validation step
+
+## Repo map
+
+- `apps/web`: React app
+- `apps/api`: Express app
+- `packages/domain`: use cases
+- `packages/shared`: shared contracts and config
+- `docs/`: architecture, progress and workflow notes
+
+## Preferred patterns
+
+- frontend server state: `@tanstack/react-query`
+- validated forms: `react-hook-form` + shared `zod` schemas
+- API route composition: modular routers under `apps/api/src/http/routes`
+- shared request/validation contracts: `packages/shared`
+- domain logic should stay independent from React and Express
+
+## Current constraints
+
+- the private workspace must remain non-obvious in the public UI
+- route is environment-driven through `VITE_ADMIN_PATH`
+- local runtime may use in-memory repositories when `DATABASE_URL` is absent
+- PostgreSQL mode must continue to work through the existing migration entrypoint
+
+## Before finishing a work block
+
+Run the relevant checks:
+
+- `npm run lint`
+- `npm run test -w @portfolio/web`
+- `npm run test -w @portfolio/api`
+
+If the change is isolated, still prefer targeted tests over broad no-op churn.
+
+## After finishing a work block
+
+- update documentation if the architecture or workflow changed
+- push the branch
+- open a PR against `dev`
+- merge it
+- ensure local `dev` is aligned with `origin/dev`

--- a/README.md
+++ b/README.md
@@ -1,58 +1,72 @@
 # Portfolio_David
 
-Rebuild del portfolio de David sobre una estructura con `apps/web`, `apps/api` y paquetes compartidos para dominio y configuración. El objetivo es tener un flujo local estable con `npm dev`, una API coherente para el panel admin y una base clara para seguir separando frontend, backend e infraestructura.
+Portfolio rebuild for David on top of a split `web` and `api` architecture with shared contracts and domain logic.
 
-El stack heredado basado en `frontend/`, `api/` y `shared/` ya no forma parte del código activo y se ha retirado del repositorio para evitar rutas muertas, configuración duplicada y ruido arquitectónico.
+The active codebase is the rebuilt stack under `apps/` and `packages/`. The old `frontend/`, `api/` and `shared/` runtime was removed from the repository and is no longer part of local development or deployment.
 
-## Stack actual
+## Current stack
 
 - `apps/web`: React + Vite
-- `apps/api`: Express modular
-- `packages/domain`: casos de uso y validación
-- `packages/shared`: seed data y configuración local compartida
+- `apps/api`: Express + modular HTTP routes
+- `packages/domain`: use cases and domain-facing orchestration
+- `packages/shared`: shared schemas, seed data and runtime config
 
-## Desarrollo local
+## Local development
 
 ```bash
 npm install
 npm run dev
 ```
 
-URLs locales:
+Local URLs:
 
 - web: `http://localhost:4173`
-- api health: `http://localhost:4173/api/health`
+- API health through Vite proxy: `http://localhost:4173/api/health`
+- private workspace route: `http://localhost:4173/studio-503`
 
-Credenciales locales por defecto:
+Default local admin credentials:
 
-- usuario: `admin`
-- contraseña: `admin123`
+- username: `admin`
+- password: `admin123`
 
-## Base de datos
+## Environment
 
-La inicialización nueva está en `apps/api/migrations`.
-
-```bash
-npm run db:migrate -w @portfolio/api
-```
-
-Si `DATABASE_URL` no está definida, la API usa adapters en memoria para que el producto siga siendo navegable y administrable en local.
-
-Variables de entorno base:
+Copy the base environment file before running local services:
 
 ```bash
 cp .env.example .env
 ```
 
-## Estado del backlog
+Important variables:
 
-Issues creadas en GitHub:
+- `API_PORT`
+- `VITE_ADMIN_PATH`
+- `JWT_SECRET`
+- `DATABASE_URL` (optional, enables PostgreSQL adapters)
+- `GMAIL_USER`, `GMAIL_APP_PASSWORD`, `RECIPIENT_EMAIL` (optional, enables email delivery)
 
-- `#1` arquitectura ports and adapters
-- `#2` rebuild frontend React compilado
-- `#3` rebuild API admin/public
-- `#4` mismatch admin/API en delete
-- `#5` contacto con fake-success
-- `#6` environment + encoding
-- `#7` migraciones SQL
-- `#8` tooling local
+## Database
+
+Run migrations for PostgreSQL-backed local development:
+
+```bash
+npm run db:migrate -w @portfolio/api
+```
+
+If `DATABASE_URL` is not defined, the API falls back to in-memory adapters so the product remains usable in local development.
+
+## Quality checks
+
+```bash
+npm run lint
+npm run test
+```
+
+`npm build` is intentionally not part of the current workflow. The local reference workflow is the stable `npm run dev` environment.
+
+## Documentation
+
+- [Architecture](./docs/architecture.md)
+- [Progress](./docs/progress.md)
+- [Workflow](./docs/workflow.md)
+- [Agents guide](./AGENTS.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,109 @@
+# Architecture
+
+## Repo shape
+
+```text
+apps/
+  api/
+  web/
+packages/
+  domain/
+  shared/
+```
+
+## Current runtime boundaries
+
+### `apps/web`
+
+- React application served by Vite in local development
+- public home page
+- private workspace route for admin tasks
+- `react-query` for server state
+- `react-hook-form` + shared `zod` schemas for validated forms
+
+### `apps/api`
+
+- Express HTTP surface
+- modular routers for:
+  - auth
+  - projects
+  - blog
+  - contact
+- reusable HTTP helpers for response shape and rate limiting
+- container-based adapter wiring
+
+### `packages/domain`
+
+- use cases:
+  - projects CRUD
+  - blog CRUD
+  - admin authentication
+  - contact submission
+  - token verification
+- no direct knowledge of Express or React
+- consumes schemas exported by `@portfolio/shared`
+
+### `packages/shared`
+
+- shared `zod` schemas
+- seed data for local/in-memory mode
+- runtime config used across apps
+
+## Ports and adapters direction
+
+The target dependency flow is:
+
+```text
+web -> shared
+api -> domain + shared
+domain -> shared
+shared -> no app dependencies
+```
+
+Infrastructure-specific code lives under `apps/api/src/adapters` and is injected through `apps/api/src/infrastructure/container.js`.
+
+## API design
+
+Current routes:
+
+- `GET /api/health`
+- `POST /api/auth/login`
+- `GET /api/auth/session`
+- `GET /api/projects`
+- `POST /api/projects`
+- `PUT /api/projects/:id`
+- `DELETE /api/projects/:id`
+- `GET /api/blog`
+- `POST /api/blog`
+- `PUT /api/blog/:id`
+- `DELETE /api/blog/:id`
+- `POST /api/contact`
+
+Response contract:
+
+- success: `{ "data": ... }`
+- failure: `{ "error": { "code": string, "message": string, "details"?: unknown } }`
+
+## Persistence modes
+
+### In-memory
+
+Used when `DATABASE_URL` is missing.
+
+- fast local startup
+- safe for UI iteration
+- non-persistent data
+
+### PostgreSQL
+
+Enabled when `DATABASE_URL` is defined.
+
+- repositories switch to postgres adapters
+- migrations live in `apps/api/migrations`
+
+## Near-term architectural work
+
+- keep moving validation contracts out of app-specific layers and into `shared`
+- reduce remaining ad hoc admin form state for project and blog CRUD
+- continue isolating auth, persistence and mail concerns behind explicit ports
+- add deeper test coverage around adapters and error contracts

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,0 +1,51 @@
+# Progress
+
+## Status as of 2026-04-01
+
+The repo is on a rebuilt stack and `dev` is the active integration branch.
+
+Completed PRs merged to `dev`:
+
+- `#9` initial rebuild toward ports and adapters
+- `#11` migrations and local development docs
+- `#12` reduce admin discoverability in public UI
+- `#13` remove remaining public admin hint
+- `#14` harden private workspace entrypoint
+- `#15` smoke tests for the rebuilt web app
+- `#16` remove obsolete legacy stack
+- `#17` add ESLint tooling across workspaces
+- `#18` modularize HTTP routes and validate admin sessions
+- `#19` adopt `react-query` for frontend server state
+- `#20` share form schemas across web and domain
+
+## GitHub issues
+
+Closed:
+
+- `#4` admin/API delete mismatch
+- `#5` fake-success contact flow
+- `#6` broken environment and encoding legacy issues
+- `#7` SQL bootstrap replaced by migrations
+- `#8` local tooling baseline
+
+Still open:
+
+- `#1` epic: rebuild architecture to ports and adapters
+- `#2` epic: rebuild frontend on compiled React
+- `#3` epic: rebuild API for admin/public workflows
+
+## Current product state
+
+- local dev is stable on `npm run dev`
+- public site served from `http://localhost:4173`
+- private workspace served from the configured hidden route
+- API health reachable through Vite proxy
+- form validation shared between frontend and domain
+- API routes split into bounded HTTP modules
+
+## Known next steps
+
+- move project and blog admin forms onto shared schema + standard form handling
+- improve field-level error handling for CRUD workflows
+- continue closing the remaining surface of epics `#2` and `#3`
+- expand adapter and integration tests

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,41 @@
+# Workflow
+
+## Branching
+
+- integration branch: `dev`
+- feature work goes on short-lived branches from `dev`
+- each meaningful block should ship in its own PR
+
+## Expected implementation flow
+
+1. branch from `dev`
+2. implement one coherent slice
+3. run:
+   - `npm run lint`
+   - targeted workspace tests
+4. push branch
+5. open PR against `dev`
+6. merge PR into `dev`
+7. update local `dev`
+
+## Local development rules
+
+- keep `npm run dev` stable
+- do not rely on `npm build` for progress
+- prefer additive refactors over large unverified rewrites
+- keep the hidden workspace route configurable through environment
+
+## Quality bar
+
+- shared contracts should not diverge between web and domain
+- API routes should expose stable success/error shapes
+- new frontend data-fetching should prefer `react-query`
+- new validated forms should prefer `react-hook-form` + shared `zod` schemas
+
+## Documentation rule
+
+Whenever the architecture or workflow materially changes:
+
+- update `README.md`
+- update `docs/architecture.md`
+- update `docs/progress.md` if issue/PR state changed


### PR DESCRIPTION
## Summary
- rewrite the README around the rebuilt stack and current local workflow
- add `docs/architecture.md`, `docs/progress.md` and `docs/workflow.md`
- add `AGENTS.md` with the working agreements for future implementation slices

## Testing
- docs-only change
- no runtime code changed